### PR TITLE
Fix 'Uncaught ReferenceError: d is not defined'

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ var simplifyGeometry = function(points, tolerance){
   var index = 0;
 
   for (var i = 1; i <= points.length - 2; i++){
-    d = new Line(points[0], points[points.length - 1]).perpendicularDistance(points[i]);
+    var d = new Line(points[0], points[points.length - 1]).perpendicularDistance(points[i]);
     if (d > dmax){
       index = i;
       dmax = d;


### PR DESCRIPTION
Defining the global variable `d` throws errors in some contexts
